### PR TITLE
Returns back ExecutionContext to Interpreter's caller 

### DIFF
--- a/fs2-aws-examples/src/main/scala/DynamoParallelScan.scala
+++ b/fs2-aws-examples/src/main/scala/DynamoParallelScan.scala
@@ -1,5 +1,5 @@
 import cats.data.Kleisli
-import cats.effect.{ Blocker, ExitCode, IO, IOApp, Sync }
+import cats.effect.{ ExitCode, IO, IOApp, Sync }
 import cats.implicits._
 import fs2.{ Chunk, Pipe }
 import fs2.aws.dynamodb.StreamScan
@@ -81,8 +81,7 @@ case class DDBEnvironment[F[_]](
 object DynamoParallelScan extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =
     (for {
-      b <- Blocker[IO]
-      ddb <- Interpreter[IO](b)
+      ddb <- Interpreter[IO]
               .DynamoDbAsyncClientOpResource(
                 DynamoDbAsyncClient
                   .builder()

--- a/fs2-aws-examples/src/main/scala/KinesisExample.scala
+++ b/fs2-aws-examples/src/main/scala/KinesisExample.scala
@@ -52,10 +52,10 @@ object KinesisExample extends IOApp {
   ) =
     for {
       b                  <- Blocker[F]
-      i                  = KinesisInterpreter[F](b)
+      i                  = KinesisInterpreter[F]
       k                  <- i.KinesisAsyncClientResource(kac)
-      d                  <- DynamoDbInterpreter[F](b).DynamoDbAsyncClientResource(dac)
-      c                  <- CloudwatchInterpreter[F](b).CloudWatchAsyncClientResource(cac)
+      d                  <- DynamoDbInterpreter[F].DynamoDbAsyncClientResource(dac)
+      c                  <- CloudwatchInterpreter[F].CloudWatchAsyncClientResource(cac)
       kinesisInterpreter = i.create(k)
       _                  <- disposableStream(kinesisInterpreter, streamName)
     } yield Kinesis.create[F](k, d, c, b)

--- a/fs2-aws-examples/src/main/scala/S3Example.scala
+++ b/fs2-aws-examples/src/main/scala/S3Example.scala
@@ -19,7 +19,7 @@ object S3Example extends IOApp {
       blocker     <- Blocker[IO]
       credentials = AwsBasicCredentials.create("accesskey", "secretkey")
       port        = 4566
-      s3 <- S3Interpreter[IO](blocker).S3AsyncClientOpResource(
+      s3 <- S3Interpreter[IO].S3AsyncClientOpResource(
              S3AsyncClient
                .builder()
                .credentialsProvider(StaticCredentialsProvider.create(credentials))

--- a/fs2-aws-s3/src/test/scala/fs2/aws/s3/S3Suite.scala
+++ b/fs2-aws-s3/src/test/scala/fs2/aws/s3/S3Suite.scala
@@ -19,7 +19,7 @@ class S3Suite extends IOSuite {
       .create("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
 
   val s3R: Resource[IO, S3AsyncClientOp[IO]] =
-    Interpreter[IO](blocker).S3AsyncClientOpResource(
+    Interpreter[IO].S3AsyncClientOpResource(
       S3AsyncClient
         .builder()
         .credentialsProvider(StaticCredentialsProvider.create(credentials))

--- a/fs2-aws-sns/src/test/scala/fs2/aws/sns/SnsSpec.scala
+++ b/fs2-aws-sns/src/test/scala/fs2/aws/sns/SnsSpec.scala
@@ -1,6 +1,6 @@
 package fs2.aws.sns
 
-import cats.effect.{ Blocker, ContextShift, IO, Resource, Timer }
+import cats.effect.{ ContextShift, IO, Resource, Timer }
 import fs2.aws.sns.sns.SNS
 import io.laserdisc.pure.sns.tagless.{ Interpreter, SnsAsyncClientOp }
 import io.laserdisc.pure.sqs.tagless
@@ -32,7 +32,6 @@ class SnsSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   var topicArn: String = _
   var queueUrl: String = _
   val pattern: Regex   = new Regex("\"Message\": \"[0-9]\"")
-  val blocker          = Blocker.liftExecutionContext(ec)
 
   override def beforeAll(): Unit =
     awsClientsResource
@@ -126,7 +125,7 @@ class SnsSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   def mkSNSClient(snsPort: Int): Resource[IO, SnsAsyncClientOp[IO]] = {
     val credentials =
       AwsBasicCredentials.create("accesskey", "secretkey")
-    Interpreter[IO](blocker).SnsAsyncClientOpResource(
+    Interpreter[IO].SnsAsyncClientOpResource(
       SnsAsyncClient
         .builder()
         .credentialsProvider(StaticCredentialsProvider.create(credentials))
@@ -139,7 +138,7 @@ class SnsSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
     val credentials =
       AwsBasicCredentials.create("accesskey", "secretkey")
     tagless
-      .Interpreter[IO](blocker)
+      .Interpreter[IO]
       .SqsAsyncClientOpResource(
         SqsAsyncClient
           .builder()

--- a/fs2-aws-sqs/src/test/scala/fs2/aws/sqs/SqsSpec.scala
+++ b/fs2-aws-sqs/src/test/scala/fs2/aws/sqs/SqsSpec.scala
@@ -1,6 +1,6 @@
 package sqs
 
-import cats.effect.{ Blocker, ContextShift, IO, Resource, Timer }
+import cats.effect.{ ContextShift, IO, Resource, Timer }
 import fs2.aws.sqs.SQS
 import io.laserdisc.pure.sqs.tagless.{ Interpreter, SqsAsyncClientOp }
 import org.scalatest.BeforeAndAfterAll
@@ -24,7 +24,6 @@ class SqsSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
     if ("fail" == text) Left(new Exception("failure"))
     else Right(text.toInt)
   }
-  val blocker                                           = Blocker.liftExecutionContext(ec)
   val sqsOpResource: Resource[IO, SqsAsyncClientOp[IO]] = mkSQSClient(4566)
   var queueUrl: String                                  = _
 
@@ -104,7 +103,7 @@ class SqsSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   def mkSQSClient(sqsPort: Int) = {
     val credentials =
       AwsBasicCredentials.create("accesskey", "secretkey")
-    Interpreter[IO](blocker).SqsAsyncClientOpResource(
+    Interpreter[IO].SqsAsyncClientOpResource(
       SqsAsyncClient
         .builder()
         .credentialsProvider(StaticCredentialsProvider.create(credentials))

--- a/fs2-aws/src/test/scala/fs2/aws/kinesis/NewLocalStackSuite.scala
+++ b/fs2-aws/src/test/scala/fs2/aws/kinesis/NewLocalStackSuite.scala
@@ -212,10 +212,10 @@ class NewLocalStackSuite extends AnyFlatSpec with Matchers with ScalaFutures {
   ) =
     for {
       b                  <- Blocker[IO]
-      i                  = KinesisInterpreter[IO](b)
+      i                  = KinesisInterpreter[IO]
       k                  <- i.KinesisAsyncClientResource(kac)
-      d                  <- DynamoDbInterpreter[IO](b).DynamoDbAsyncClientResource(dac)
-      c                  <- CloudwatchInterpreter[IO](b).CloudWatchAsyncClientResource(cac)
+      d                  <- DynamoDbInterpreter[IO].DynamoDbAsyncClientResource(dac)
+      c                  <- CloudwatchInterpreter[IO].CloudWatchAsyncClientResource(cac)
       kinesisInterpreter = i.create(k)
       kAlgebra           = Kinesis.create[IO](k, d, c, b)
     } yield kinesisInterpreter -> kAlgebra

--- a/pure-aws/pure-cloudwatch-tagless/src/main/scala/io/laserdisc/pure/cloudwatch/tagless/CloudWatchAsyncClientOp.scala
+++ b/pure-aws/pure-cloudwatch-tagless/src/main/scala/io/laserdisc/pure/cloudwatch/tagless/CloudWatchAsyncClientOp.scala
@@ -5,6 +5,7 @@ import software.amazon.awssdk.services.cloudwatch.model.{
   DeleteAnomalyDetectorRequest,
   DeleteDashboardsRequest,
   DeleteInsightRulesRequest,
+  DeleteMetricStreamRequest,
   DescribeAlarmHistoryRequest,
   DescribeAlarmsForMetricRequest,
   DescribeAlarmsRequest,
@@ -18,8 +19,10 @@ import software.amazon.awssdk.services.cloudwatch.model.{
   GetInsightRuleReportRequest,
   GetMetricDataRequest,
   GetMetricStatisticsRequest,
+  GetMetricStreamRequest,
   GetMetricWidgetImageRequest,
   ListDashboardsRequest,
+  ListMetricStreamsRequest,
   ListMetricsRequest,
   ListTagsForResourceRequest,
   PutAnomalyDetectorRequest,
@@ -28,12 +31,23 @@ import software.amazon.awssdk.services.cloudwatch.model.{
   PutInsightRuleRequest,
   PutMetricAlarmRequest,
   PutMetricDataRequest,
+  PutMetricStreamRequest,
   SetAlarmStateRequest,
+  StartMetricStreamsRequest,
+  StopMetricStreamsRequest,
   TagResourceRequest,
   UntagResourceRequest,
   _
 }
-import software.amazon.awssdk.services.cloudwatch.paginators._
+import software.amazon.awssdk.services.cloudwatch.paginators.{
+  DescribeAlarmHistoryPublisher,
+  DescribeAlarmsPublisher,
+  DescribeInsightRulesPublisher,
+  GetMetricDataPublisher,
+  ListDashboardsPublisher,
+  ListMetricStreamsPublisher,
+  ListMetricsPublisher
+}
 import software.amazon.awssdk.services.cloudwatch.waiters.CloudWatchAsyncWaiter
 
 trait CloudWatchAsyncClientOp[F[_]] {
@@ -43,6 +57,7 @@ trait CloudWatchAsyncClientOp[F[_]] {
   def deleteAnomalyDetector(a: DeleteAnomalyDetectorRequest): F[DeleteAnomalyDetectorResponse]
   def deleteDashboards(a: DeleteDashboardsRequest): F[DeleteDashboardsResponse]
   def deleteInsightRules(a: DeleteInsightRulesRequest): F[DeleteInsightRulesResponse]
+  def deleteMetricStream(a: DeleteMetricStreamRequest): F[DeleteMetricStreamResponse]
   def describeAlarmHistory: F[DescribeAlarmHistoryResponse]
   def describeAlarmHistory(a: DescribeAlarmHistoryRequest): F[DescribeAlarmHistoryResponse]
   def describeAlarmHistoryPaginator: F[DescribeAlarmHistoryPublisher]
@@ -70,11 +85,14 @@ trait CloudWatchAsyncClientOp[F[_]] {
   def getMetricData(a: GetMetricDataRequest): F[GetMetricDataResponse]
   def getMetricDataPaginator(a: GetMetricDataRequest): F[GetMetricDataPublisher]
   def getMetricStatistics(a: GetMetricStatisticsRequest): F[GetMetricStatisticsResponse]
+  def getMetricStream(a: GetMetricStreamRequest): F[GetMetricStreamResponse]
   def getMetricWidgetImage(a: GetMetricWidgetImageRequest): F[GetMetricWidgetImageResponse]
   def listDashboards: F[ListDashboardsResponse]
   def listDashboards(a: ListDashboardsRequest): F[ListDashboardsResponse]
   def listDashboardsPaginator: F[ListDashboardsPublisher]
   def listDashboardsPaginator(a: ListDashboardsRequest): F[ListDashboardsPublisher]
+  def listMetricStreams(a: ListMetricStreamsRequest): F[ListMetricStreamsResponse]
+  def listMetricStreamsPaginator(a: ListMetricStreamsRequest): F[ListMetricStreamsPublisher]
   def listMetrics: F[ListMetricsResponse]
   def listMetrics(a: ListMetricsRequest): F[ListMetricsResponse]
   def listMetricsPaginator: F[ListMetricsPublisher]
@@ -86,8 +104,11 @@ trait CloudWatchAsyncClientOp[F[_]] {
   def putInsightRule(a: PutInsightRuleRequest): F[PutInsightRuleResponse]
   def putMetricAlarm(a: PutMetricAlarmRequest): F[PutMetricAlarmResponse]
   def putMetricData(a: PutMetricDataRequest): F[PutMetricDataResponse]
+  def putMetricStream(a: PutMetricStreamRequest): F[PutMetricStreamResponse]
   def serviceName: F[String]
   def setAlarmState(a: SetAlarmStateRequest): F[SetAlarmStateResponse]
+  def startMetricStreams(a: StartMetricStreamsRequest): F[StartMetricStreamsResponse]
+  def stopMetricStreams(a: StopMetricStreamsRequest): F[StopMetricStreamsResponse]
   def tagResource(a: TagResourceRequest): F[TagResourceResponse]
   def untagResource(a: UntagResourceRequest): F[UntagResourceResponse]
   def waiter: F[CloudWatchAsyncWaiter]

--- a/pure-aws/pure-cloudwatch-tagless/src/main/scala/io/laserdisc/pure/cloudwatch/tagless/Interpreter.scala
+++ b/pure-aws/pure-cloudwatch-tagless/src/main/scala/io/laserdisc/pure/cloudwatch/tagless/Interpreter.scala
@@ -14,6 +14,7 @@ import software.amazon.awssdk.services.cloudwatch.model.{
   DeleteAnomalyDetectorRequest,
   DeleteDashboardsRequest,
   DeleteInsightRulesRequest,
+  DeleteMetricStreamRequest,
   DescribeAlarmHistoryRequest,
   DescribeAlarmsForMetricRequest,
   DescribeAlarmsRequest,
@@ -27,8 +28,10 @@ import software.amazon.awssdk.services.cloudwatch.model.{
   GetInsightRuleReportRequest,
   GetMetricDataRequest,
   GetMetricStatisticsRequest,
+  GetMetricStreamRequest,
   GetMetricWidgetImageRequest,
   ListDashboardsRequest,
+  ListMetricStreamsRequest,
   ListMetricsRequest,
   ListTagsForResourceRequest,
   PutAnomalyDetectorRequest,
@@ -37,7 +40,10 @@ import software.amazon.awssdk.services.cloudwatch.model.{
   PutInsightRuleRequest,
   PutMetricAlarmRequest,
   PutMetricDataRequest,
+  PutMetricStreamRequest,
   SetAlarmStateRequest,
+  StartMetricStreamsRequest,
+  StopMetricStreamsRequest,
   TagResourceRequest,
   UntagResourceRequest
 }
@@ -46,6 +52,7 @@ import java.util.concurrent.CompletableFuture
 
 object Interpreter {
 
+  @deprecated("Use Interpreter[M]. blocker is not needed anymore", "3.2.0")
   def apply[M[_]](b: Blocker)(
     implicit am: Async[M],
     cs: ContextShift[M]
@@ -53,7 +60,15 @@ object Interpreter {
     new Interpreter[M] {
       val asyncM        = am
       val contextShiftM = cs
-      val blocker       = b
+    }
+
+  def apply[M[_]](
+    implicit am: Async[M],
+    cs: ContextShift[M]
+  ): Interpreter[M] =
+    new Interpreter[M] {
+      val asyncM        = am
+      val contextShiftM = cs
     }
 
 }
@@ -65,53 +80,33 @@ trait Interpreter[M[_]] { outer =>
 
   // to support shifting blocking operations to another pool.
   val contextShiftM: ContextShift[M]
-  val blocker: Blocker
 
   lazy val CloudWatchAsyncClientInterpreter: CloudWatchAsyncClientInterpreter =
     new CloudWatchAsyncClientInterpreter {}
   // Some methods are common to all interpreters and can be overridden to change behavior globally.
 
-  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli { a =>
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f(a))
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
-  }
-  def primitive1[J, A](f: =>A): M[A] =
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f)
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
+  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli(a => primitive1(f(a)))
 
-  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli { a =>
-    asyncM.async { cb =>
-      fut(a).handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
-          }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
-  }
+  def primitive1[J, A](f: =>A): M[A] = asyncM.delay(f)
+
+  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli(a => eff1(fut(a)))
+
   def eff1[J, A](fut: =>CompletableFuture[A]): M[A] =
-    asyncM.async { cb =>
-      fut.handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
+    asyncM.guarantee(
+      asyncM
+        .async[A] { cb =>
+          fut.handle[Unit] { (a, x) =>
+            if (a == null)
+              x match {
+                case t: CompletionException => cb(Left(t.getCause))
+                case t                      => cb(Left(t))
+              }
+            else
+              cb(Right(a))
           }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
+          ()
+        }
+    )(contextShiftM.shift)
 
   // Interpreters
   trait CloudWatchAsyncClientInterpreter
@@ -124,6 +119,7 @@ trait Interpreter[M[_]] { outer =>
       eff(_.deleteAnomalyDetector(a))
     override def deleteDashboards(a: DeleteDashboardsRequest)     = eff(_.deleteDashboards(a))
     override def deleteInsightRules(a: DeleteInsightRulesRequest) = eff(_.deleteInsightRules(a))
+    override def deleteMetricStream(a: DeleteMetricStreamRequest) = eff(_.deleteMetricStream(a))
     override def describeAlarmHistory                             = eff(_.describeAlarmHistory)
     override def describeAlarmHistory(a: DescribeAlarmHistoryRequest) =
       eff(_.describeAlarmHistory(a))
@@ -154,6 +150,7 @@ trait Interpreter[M[_]] { outer =>
     override def getMetricDataPaginator(a: GetMetricDataRequest) =
       primitive(_.getMetricDataPaginator(a))
     override def getMetricStatistics(a: GetMetricStatisticsRequest) = eff(_.getMetricStatistics(a))
+    override def getMetricStream(a: GetMetricStreamRequest)         = eff(_.getMetricStream(a))
     override def getMetricWidgetImage(a: GetMetricWidgetImageRequest) =
       eff(_.getMetricWidgetImage(a))
     override def listDashboards                           = eff(_.listDashboards)
@@ -161,6 +158,9 @@ trait Interpreter[M[_]] { outer =>
     override def listDashboardsPaginator                  = primitive(_.listDashboardsPaginator)
     override def listDashboardsPaginator(a: ListDashboardsRequest) =
       primitive(_.listDashboardsPaginator(a))
+    override def listMetricStreams(a: ListMetricStreamsRequest) = eff(_.listMetricStreams(a))
+    override def listMetricStreamsPaginator(a: ListMetricStreamsRequest) =
+      primitive(_.listMetricStreamsPaginator(a))
     override def listMetrics                                        = eff(_.listMetrics)
     override def listMetrics(a: ListMetricsRequest)                 = eff(_.listMetrics(a))
     override def listMetricsPaginator                               = primitive(_.listMetricsPaginator)
@@ -172,8 +172,11 @@ trait Interpreter[M[_]] { outer =>
     override def putInsightRule(a: PutInsightRuleRequest)           = eff(_.putInsightRule(a))
     override def putMetricAlarm(a: PutMetricAlarmRequest)           = eff(_.putMetricAlarm(a))
     override def putMetricData(a: PutMetricDataRequest)             = eff(_.putMetricData(a))
+    override def putMetricStream(a: PutMetricStreamRequest)         = eff(_.putMetricStream(a))
     override def serviceName                                        = primitive(_.serviceName)
     override def setAlarmState(a: SetAlarmStateRequest)             = eff(_.setAlarmState(a))
+    override def startMetricStreams(a: StartMetricStreamsRequest)   = eff(_.startMetricStreams(a))
+    override def stopMetricStreams(a: StopMetricStreamsRequest)     = eff(_.stopMetricStreams(a))
     override def tagResource(a: TagResourceRequest)                 = eff(_.tagResource(a))
     override def untagResource(a: UntagResourceRequest)             = eff(_.untagResource(a))
     override def waiter                                             = primitive(_.waiter)
@@ -187,6 +190,8 @@ trait Interpreter[M[_]] { outer =>
           Kleisli(e => eff1(f(e).deleteDashboards(a)))
         override def deleteInsightRules(a: DeleteInsightRulesRequest) =
           Kleisli(e => eff1(f(e).deleteInsightRules(a)))
+        override def deleteMetricStream(a: DeleteMetricStreamRequest) =
+          Kleisli(e => eff1(f(e).deleteMetricStream(a)))
         override def describeAlarmHistory = Kleisli(e => eff1(f(e).describeAlarmHistory))
         override def describeAlarmHistory(a: DescribeAlarmHistoryRequest) =
           Kleisli(e => eff1(f(e).describeAlarmHistory(a)))
@@ -226,6 +231,8 @@ trait Interpreter[M[_]] { outer =>
           Kleisli(e => primitive1(f(e).getMetricDataPaginator(a)))
         override def getMetricStatistics(a: GetMetricStatisticsRequest) =
           Kleisli(e => eff1(f(e).getMetricStatistics(a)))
+        override def getMetricStream(a: GetMetricStreamRequest) =
+          Kleisli(e => eff1(f(e).getMetricStream(a)))
         override def getMetricWidgetImage(a: GetMetricWidgetImageRequest) =
           Kleisli(e => eff1(f(e).getMetricWidgetImage(a)))
         override def listDashboards = Kleisli(e => eff1(f(e).listDashboards))
@@ -235,6 +242,10 @@ trait Interpreter[M[_]] { outer =>
           Kleisli(e => primitive1(f(e).listDashboardsPaginator))
         override def listDashboardsPaginator(a: ListDashboardsRequest) =
           Kleisli(e => primitive1(f(e).listDashboardsPaginator(a)))
+        override def listMetricStreams(a: ListMetricStreamsRequest) =
+          Kleisli(e => eff1(f(e).listMetricStreams(a)))
+        override def listMetricStreamsPaginator(a: ListMetricStreamsRequest) =
+          Kleisli(e => primitive1(f(e).listMetricStreamsPaginator(a)))
         override def listMetrics                        = Kleisli(e => eff1(f(e).listMetrics))
         override def listMetrics(a: ListMetricsRequest) = Kleisli(e => eff1(f(e).listMetrics(a)))
         override def listMetricsPaginator               = Kleisli(e => primitive1(f(e).listMetricsPaginator))
@@ -253,9 +264,15 @@ trait Interpreter[M[_]] { outer =>
           Kleisli(e => eff1(f(e).putMetricAlarm(a)))
         override def putMetricData(a: PutMetricDataRequest) =
           Kleisli(e => eff1(f(e).putMetricData(a)))
+        override def putMetricStream(a: PutMetricStreamRequest) =
+          Kleisli(e => eff1(f(e).putMetricStream(a)))
         override def serviceName = Kleisli(e => primitive1(f(e).serviceName))
         override def setAlarmState(a: SetAlarmStateRequest) =
           Kleisli(e => eff1(f(e).setAlarmState(a)))
+        override def startMetricStreams(a: StartMetricStreamsRequest) =
+          Kleisli(e => eff1(f(e).startMetricStreams(a)))
+        override def stopMetricStreams(a: StopMetricStreamsRequest) =
+          Kleisli(e => eff1(f(e).stopMetricStreams(a)))
         override def tagResource(a: TagResourceRequest) = Kleisli(e => eff1(f(e).tagResource(a)))
         override def untagResource(a: UntagResourceRequest) =
           Kleisli(e => eff1(f(e).untagResource(a)))
@@ -279,6 +296,8 @@ trait Interpreter[M[_]] { outer =>
       override def deleteDashboards(a: DeleteDashboardsRequest) = eff1(client.deleteDashboards(a))
       override def deleteInsightRules(a: DeleteInsightRulesRequest) =
         eff1(client.deleteInsightRules(a))
+      override def deleteMetricStream(a: DeleteMetricStreamRequest) =
+        eff1(client.deleteMetricStream(a))
       override def describeAlarmHistory = eff1(client.describeAlarmHistory)
       override def describeAlarmHistory(a: DescribeAlarmHistoryRequest) =
         eff1(client.describeAlarmHistory(a))
@@ -314,6 +333,7 @@ trait Interpreter[M[_]] { outer =>
         primitive1(client.getMetricDataPaginator(a))
       override def getMetricStatistics(a: GetMetricStatisticsRequest) =
         eff1(client.getMetricStatistics(a))
+      override def getMetricStream(a: GetMetricStreamRequest) = eff1(client.getMetricStream(a))
       override def getMetricWidgetImage(a: GetMetricWidgetImageRequest) =
         eff1(client.getMetricWidgetImage(a))
       override def listDashboards                           = eff1(client.listDashboards)
@@ -321,6 +341,10 @@ trait Interpreter[M[_]] { outer =>
       override def listDashboardsPaginator                  = primitive1(client.listDashboardsPaginator)
       override def listDashboardsPaginator(a: ListDashboardsRequest) =
         primitive1(client.listDashboardsPaginator(a))
+      override def listMetricStreams(a: ListMetricStreamsRequest) =
+        eff1(client.listMetricStreams(a))
+      override def listMetricStreamsPaginator(a: ListMetricStreamsRequest) =
+        primitive1(client.listMetricStreamsPaginator(a))
       override def listMetrics                        = eff1(client.listMetrics)
       override def listMetrics(a: ListMetricsRequest) = eff1(client.listMetrics(a))
       override def listMetricsPaginator               = primitive1(client.listMetricsPaginator)
@@ -332,15 +356,20 @@ trait Interpreter[M[_]] { outer =>
         eff1(client.putAnomalyDetector(a))
       override def putCompositeAlarm(a: PutCompositeAlarmRequest) =
         eff1(client.putCompositeAlarm(a))
-      override def putDashboard(a: PutDashboardRequest)     = eff1(client.putDashboard(a))
-      override def putInsightRule(a: PutInsightRuleRequest) = eff1(client.putInsightRule(a))
-      override def putMetricAlarm(a: PutMetricAlarmRequest) = eff1(client.putMetricAlarm(a))
-      override def putMetricData(a: PutMetricDataRequest)   = eff1(client.putMetricData(a))
-      override def serviceName                              = primitive1(client.serviceName)
-      override def setAlarmState(a: SetAlarmStateRequest)   = eff1(client.setAlarmState(a))
-      override def tagResource(a: TagResourceRequest)       = eff1(client.tagResource(a))
-      override def untagResource(a: UntagResourceRequest)   = eff1(client.untagResource(a))
-      override def waiter                                   = primitive1(client.waiter)
+      override def putDashboard(a: PutDashboardRequest)       = eff1(client.putDashboard(a))
+      override def putInsightRule(a: PutInsightRuleRequest)   = eff1(client.putInsightRule(a))
+      override def putMetricAlarm(a: PutMetricAlarmRequest)   = eff1(client.putMetricAlarm(a))
+      override def putMetricData(a: PutMetricDataRequest)     = eff1(client.putMetricData(a))
+      override def putMetricStream(a: PutMetricStreamRequest) = eff1(client.putMetricStream(a))
+      override def serviceName                                = primitive1(client.serviceName)
+      override def setAlarmState(a: SetAlarmStateRequest)     = eff1(client.setAlarmState(a))
+      override def startMetricStreams(a: StartMetricStreamsRequest) =
+        eff1(client.startMetricStreams(a))
+      override def stopMetricStreams(a: StopMetricStreamsRequest) =
+        eff1(client.stopMetricStreams(a))
+      override def tagResource(a: TagResourceRequest)     = eff1(client.tagResource(a))
+      override def untagResource(a: UntagResourceRequest) = eff1(client.untagResource(a))
+      override def waiter                                 = primitive1(client.waiter)
 
     }
 

--- a/pure-aws/pure-dynamodb-tagless/src/main/scala/io/laserdisc/pure/dynamodb/tagless/DynamoDbAsyncClientOp.scala
+++ b/pure-aws/pure-dynamodb-tagless/src/main/scala/io/laserdisc/pure/dynamodb/tagless/DynamoDbAsyncClientOp.scala
@@ -53,7 +53,14 @@ import software.amazon.awssdk.services.dynamodb.model.{
   UpdateTimeToLiveRequest,
   _
 }
-import software.amazon.awssdk.services.dynamodb.paginators._
+import software.amazon.awssdk.services.dynamodb.paginators.{
+  BatchGetItemPublisher,
+  ListContributorInsightsPublisher,
+  ListExportsPublisher,
+  ListTablesPublisher,
+  QueryPublisher,
+  ScanPublisher
+}
 import software.amazon.awssdk.services.dynamodb.waiters.DynamoDbAsyncWaiter
 
 trait DynamoDbAsyncClientOp[F[_]] {

--- a/pure-aws/pure-dynamodb-tagless/src/main/scala/io/laserdisc/pure/dynamodb/tagless/Interpreter.scala
+++ b/pure-aws/pure-dynamodb-tagless/src/main/scala/io/laserdisc/pure/dynamodb/tagless/Interpreter.scala
@@ -66,6 +66,7 @@ import java.util.concurrent.CompletableFuture
 
 object Interpreter {
 
+  @deprecated("Use Interpreter[M]. blocker is not needed anymore", "3.2.0")
   def apply[M[_]](b: Blocker)(
     implicit am: Async[M],
     cs: ContextShift[M]
@@ -73,7 +74,15 @@ object Interpreter {
     new Interpreter[M] {
       val asyncM        = am
       val contextShiftM = cs
-      val blocker       = b
+    }
+
+  def apply[M[_]](
+    implicit am: Async[M],
+    cs: ContextShift[M]
+  ): Interpreter[M] =
+    new Interpreter[M] {
+      val asyncM        = am
+      val contextShiftM = cs
     }
 
 }
@@ -85,53 +94,33 @@ trait Interpreter[M[_]] { outer =>
 
   // to support shifting blocking operations to another pool.
   val contextShiftM: ContextShift[M]
-  val blocker: Blocker
 
   lazy val DynamoDbAsyncClientInterpreter: DynamoDbAsyncClientInterpreter =
     new DynamoDbAsyncClientInterpreter {}
   // Some methods are common to all interpreters and can be overridden to change behavior globally.
 
-  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli { a =>
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f(a))
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
-  }
-  def primitive1[J, A](f: =>A): M[A] =
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f)
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
+  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli(a => primitive1(f(a)))
 
-  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli { a =>
-    asyncM.async { cb =>
-      fut(a).handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
-          }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
-  }
+  def primitive1[J, A](f: =>A): M[A] = asyncM.delay(f)
+
+  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli(a => eff1(fut(a)))
+
   def eff1[J, A](fut: =>CompletableFuture[A]): M[A] =
-    asyncM.async { cb =>
-      fut.handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
+    asyncM.guarantee(
+      asyncM
+        .async[A] { cb =>
+          fut.handle[Unit] { (a, x) =>
+            if (a == null)
+              x match {
+                case t: CompletionException => cb(Left(t.getCause))
+                case t                      => cb(Left(t))
+              }
+            else
+              cb(Right(a))
           }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
+          ()
+        }
+    )(contextShiftM.shift)
 
   // Interpreters
   trait DynamoDbAsyncClientInterpreter

--- a/pure-aws/pure-kinesis-tagless/src/main/scala/io/laserdisc/pure/kinesis/tagless/Interpreter.scala
+++ b/pure-aws/pure-kinesis-tagless/src/main/scala/io/laserdisc/pure/kinesis/tagless/Interpreter.scala
@@ -45,6 +45,7 @@ import java.util.concurrent.CompletableFuture
 
 object Interpreter {
 
+  @deprecated("Use Interpreter[M]. blocker is not needed anymore", "3.2.0")
   def apply[M[_]](b: Blocker)(
     implicit am: Async[M],
     cs: ContextShift[M]
@@ -52,7 +53,15 @@ object Interpreter {
     new Interpreter[M] {
       val asyncM        = am
       val contextShiftM = cs
-      val blocker       = b
+    }
+
+  def apply[M[_]](
+    implicit am: Async[M],
+    cs: ContextShift[M]
+  ): Interpreter[M] =
+    new Interpreter[M] {
+      val asyncM        = am
+      val contextShiftM = cs
     }
 
 }
@@ -64,53 +73,33 @@ trait Interpreter[M[_]] { outer =>
 
   // to support shifting blocking operations to another pool.
   val contextShiftM: ContextShift[M]
-  val blocker: Blocker
 
   lazy val KinesisAsyncClientInterpreter: KinesisAsyncClientInterpreter =
     new KinesisAsyncClientInterpreter {}
   // Some methods are common to all interpreters and can be overridden to change behavior globally.
 
-  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli { a =>
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f(a))
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
-  }
-  def primitive1[J, A](f: =>A): M[A] =
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f)
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
+  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli(a => primitive1(f(a)))
 
-  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli { a =>
-    asyncM.async { cb =>
-      fut(a).handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
-          }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
-  }
+  def primitive1[J, A](f: =>A): M[A] = asyncM.delay(f)
+
+  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli(a => eff1(fut(a)))
+
   def eff1[J, A](fut: =>CompletableFuture[A]): M[A] =
-    asyncM.async { cb =>
-      fut.handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
+    asyncM.guarantee(
+      asyncM
+        .async[A] { cb =>
+          fut.handle[Unit] { (a, x) =>
+            if (a == null)
+              x match {
+                case t: CompletionException => cb(Left(t.getCause))
+                case t                      => cb(Left(t))
+              }
+            else
+              cb(Right(a))
           }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
+          ()
+        }
+    )(contextShiftM.shift)
 
   // Interpreters
   trait KinesisAsyncClientInterpreter

--- a/pure-aws/pure-s3-tagless/src/main/scala/io/laserdisc/pure/s3/tagless/S3AsyncClientOp.scala
+++ b/pure-aws/pure-s3-tagless/src/main/scala/io/laserdisc/pure/s3/tagless/S3AsyncClientOp.scala
@@ -93,6 +93,7 @@ import software.amazon.awssdk.services.s3.model.{
   RestoreObjectRequest,
   UploadPartCopyRequest,
   UploadPartRequest,
+  WriteGetObjectResponseRequest,
   _
 }
 import software.amazon.awssdk.services.s3.paginators.{
@@ -272,5 +273,13 @@ trait S3AsyncClientOp[F[_]] {
   def uploadPartCopy(a: UploadPartCopyRequest): F[UploadPartCopyResponse]
   def utilities: F[S3Utilities]
   def waiter: F[S3AsyncWaiter]
+  def writeGetObjectResponse(
+    a: WriteGetObjectResponseRequest,
+    b: AsyncRequestBody
+  ): F[WriteGetObjectResponseResponse]
+  def writeGetObjectResponse(
+    a: WriteGetObjectResponseRequest,
+    b: Path
+  ): F[WriteGetObjectResponseResponse]
 
 }

--- a/pure-aws/pure-sns-tagless/src/main/scala/io/laserdisc/pure/sns/tagless/SnsAsyncClientOp.scala
+++ b/pure-aws/pure-sns-tagless/src/main/scala/io/laserdisc/pure/sns/tagless/SnsAsyncClientOp.scala
@@ -36,7 +36,13 @@ import software.amazon.awssdk.services.sns.model.{
   UntagResourceRequest,
   _
 }
-import software.amazon.awssdk.services.sns.paginators._
+import software.amazon.awssdk.services.sns.paginators.{
+  ListEndpointsByPlatformApplicationPublisher,
+  ListPlatformApplicationsPublisher,
+  ListSubscriptionsByTopicPublisher,
+  ListSubscriptionsPublisher,
+  ListTopicsPublisher
+}
 
 trait SnsAsyncClientOp[F[_]] {
   // SnsAsyncClient

--- a/pure-aws/pure-sqs-tagless/src/main/scala/io/laserdisc/pure/sqs/tagless/Interpreter.scala
+++ b/pure-aws/pure-sqs-tagless/src/main/scala/io/laserdisc/pure/sqs/tagless/Interpreter.scala
@@ -36,6 +36,7 @@ import java.util.concurrent.CompletableFuture
 
 object Interpreter {
 
+  @deprecated("Use Interpreter[M]. blocker is not needed anymore", "3.2.0")
   def apply[M[_]](b: Blocker)(
     implicit am: Async[M],
     cs: ContextShift[M]
@@ -43,7 +44,15 @@ object Interpreter {
     new Interpreter[M] {
       val asyncM        = am
       val contextShiftM = cs
-      val blocker       = b
+    }
+
+  def apply[M[_]](
+    implicit am: Async[M],
+    cs: ContextShift[M]
+  ): Interpreter[M] =
+    new Interpreter[M] {
+      val asyncM        = am
+      val contextShiftM = cs
     }
 
 }
@@ -55,52 +64,32 @@ trait Interpreter[M[_]] { outer =>
 
   // to support shifting blocking operations to another pool.
   val contextShiftM: ContextShift[M]
-  val blocker: Blocker
 
   lazy val SqsAsyncClientInterpreter: SqsAsyncClientInterpreter = new SqsAsyncClientInterpreter {}
   // Some methods are common to all interpreters and can be overridden to change behavior globally.
 
-  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli { a =>
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f(a))
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
-  }
-  def primitive1[J, A](f: =>A): M[A] =
-    blocker.blockOn[M, A](try {
-      asyncM.delay(f)
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    })(contextShiftM)
+  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli(a => primitive1(f(a)))
 
-  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli { a =>
-    asyncM.async { cb =>
-      fut(a).handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
-          }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
-  }
+  def primitive1[J, A](f: =>A): M[A] = asyncM.delay(f)
+
+  def eff[J, A](fut: J => CompletableFuture[A]): Kleisli[M, J, A] = Kleisli(a => eff1(fut(a)))
+
   def eff1[J, A](fut: =>CompletableFuture[A]): M[A] =
-    asyncM.async { cb =>
-      fut.handle[Unit] { (a, x) =>
-        if (a == null)
-          x match {
-            case t: CompletionException => cb(Left(t.getCause))
-            case t                      => cb(Left(t))
+    asyncM.guarantee(
+      asyncM
+        .async[A] { cb =>
+          fut.handle[Unit] { (a, x) =>
+            if (a == null)
+              x match {
+                case t: CompletionException => cb(Left(t.getCause))
+                case t                      => cb(Left(t))
+              }
+            else
+              cb(Right(a))
           }
-        else
-          cb(Right(a))
-      }
-      ()
-    }
+          ()
+        }
+    )(contextShiftM.shift)
 
   // Interpreters
   trait SqsAsyncClientInterpreter extends SqsAsyncClientOp[Kleisli[M, SqsAsyncClient, *]] {


### PR DESCRIPTION
Current interpreters calls are shifting to the internal aws sdk async completion thread pool and not returning back to the caller's thread pool but they are solved
That makes client application to execute following continuations code on internal aws sdk thread pool intead of the caller's one, this can cause unexpected problems and the default behaviour should be to continue caller's computations on same thread pool

See:
typelevel.org/cats-effect/docs/migration-guide#shifting
typelevel/cats-effect#582 (comment)
aws/aws-sdk-java-v2@2.16.59/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java#L310
http4s/http4s-jdk-http-client@v0.4.0-M3/core/src/main/scala/org/http4s/client/jdkhttpclient/package.scala#L51
Spinoco/fs2-cassandra@v0.4.0/core/src/main/scala/spinoco/fs2/cassandra/cassandra.scala#L15