### PR TITLE
Returns back ExecutionContext to Interpreter's caller (v3.0.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   pull_request:
-    branches: [series/3.x.x]
+    branches: [series/3.x.x, 3.1.0, shift-to-caller-ec-2]
   push:
-    branches: [series/3.x.x]
+    branches: [series/3.x.x, 3.1.0, shift-to-caller-ec-2]
 
 jobs:
   build:


### PR DESCRIPTION
Current interpreters calls are shifting to the internal aws sdk async completion thread pool and not returning back to the caller's thread pool but they are solved
That makes client application to execute following continuations code on internal aws sdk thread pool intead of the caller's one, this can cause unexpected problems and the default behaviour should be to continue caller's computations on same thread pool

See:
https://typelevel.org/cats-effect/docs/migration-guide#shifting
https://github.com/typelevel/cats-effect/issues/582#issuecomment-509703357
https://github.com/aws/aws-sdk-java-v2/blob/2.16.59/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java#L310
https://github.com/http4s/http4s-jdk-http-client/blob/v0.4.0-M3/core/src/main/scala/org/http4s/client/jdkhttpclient/package.scala#L51
https://github.com/Spinoco/fs2-cassandra/blob/v0.4.0/core/src/main/scala/spinoco/fs2/cassandra/cassandra.scala#L15